### PR TITLE
Separate repo for a particular subdirectory and subtree merge

### DIFF
--- a/git-reference-card
+++ b/git-reference-card
@@ -48,7 +48,11 @@ git merge -s ours master                                   #Useful when the code
 git checkout master
 git merge dev
 ---
-
+# merge project A into subdirectory A - From http://jasonkarns.com/blog/merge-two-git-repositories-into-one/
+git remote add -f projA /path/to/projA                    #Path should be a remote.
+git merge -s ours --no-commit projA/master
+git read-tree --prefix=subdirA/ -u projA/master
+git ci -m "merging projA into subdirA"                    #This makes your history look like this directory was in the repo all along
 * Tagging
 git tag -u <key-id> <tagname> <commitid>                   #Create a tag signed using gpg
 git push <remotename> <tagname>                            #Push single tag to remote


### PR DESCRIPTION
Hey,

Added a sequence of commands to carve out a separate repo for a particular sub-directory.

This deletes all previous commits un-related to that directory, basically making the commit that created this directory as the Initial commit. Pull if you find it worth-while. 

I used it to create a separate repo for a particular assignments from repo of class --

class/
       /proj1/
       /proj2/
       /proj3/

The above sequence can be used to create a separate repo for any proj.

Sub-tree merge does the opposite of the above

Thanks,

Chinmay
