### PR TITLE
Rewrite your Email Address (Author Information) in all the commits

### DIFF
--- a/git-notes.txt
+++ b/git-notes.txt
@@ -291,7 +291,7 @@ $ git apply --whitespace=fix
 # Rewrite Author's email address
 # WARNING: This rewrites every commit in repository i.e. All SHAs will
 #          change. Use this on a New repository
-git filter-branch --commit-filter '
+$ git filter-branch --commit-filter '
         if [ "$GIT_AUTHOR_EMAIL" = "original_email_address" ];
         then
                 GIT_AUTHOR_NAME="FirstName LastName";


### PR DESCRIPTION
Sometimes you realize that you forgot to change your email address for a local repo using git-config command. So you end up with old/unrelated email address. Added command can rewrite Author of such commits. 

But you should make note that it changes SHA of every commit.
